### PR TITLE
downgrading next due to rumored mem leak

### DIFF
--- a/backend/codebase/hasti_api/package.json
+++ b/backend/codebase/hasti_api/package.json
@@ -15,7 +15,7 @@
     "@types/react-dom": "18.2.7",
     "eslint": "8.45.0",
     "eslint-config-next": "13.4.10",
-    "next": "13.4.9",
+    "next": "13.3.4",
     "prisma": "^5.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",


### PR DESCRIPTION
https://github.com/vercel/next.js/issues/49929